### PR TITLE
fix laziness bug in implicit queue and deque

### DIFF
--- a/deque/implicit.rkt
+++ b/deque/implicit.rkt
@@ -53,12 +53,13 @@
     [(struct Deep ((struct Two (a b)) m r)) 
      (Deep (Three elem a b) m r)]
     [(struct Deep ((struct Three (f s t)) m r)) 
-     (let* ([forced-mid (force m)]
-            [first (car forced-mid)]
-            [second (cdr forced-mid)])
-       (Deep (Two elem f) 
-             (delay (cons (enqueue-front s first) (enqueue-front t second)))
-             r))]))
+     (Deep (Two elem f) 
+           (delay 
+             (let* ([forced-mid (force m)]
+                    [first (car forced-mid)]
+                    [second (cdr forced-mid)])
+               (cons (enqueue-front s first) (enqueue-front t second))))
+           r)]))
 
 ;; Inserts into the rear of the queue
 (: enqueue : (All (A) (A (Deque A) -> (Deque A))))
@@ -75,12 +76,12 @@
     [(struct Deep (f m (struct Two (a b)))) 
      (Deep f m (Three a b elem))]
     [(struct Deep (fi m (struct Three (f s t)))) 
-     (let* ([forced-mid (force m)]
-            [first (car forced-mid)]
-            [second (cdr forced-mid)])
-       (Deep fi
-             (delay (cons (enqueue f first) (enqueue s second)))
-             (Two t elem)))]))
+     (Deep fi 
+           (delay (let* ([forced-mid (force m)]
+                         [first (car forced-mid)]
+                         [second (cdr forced-mid)])
+                    (cons (enqueue f first) (enqueue s second))))
+           (Two t elem))]))
 
 ;; Returns the first element of the deque
 (: head : (All (A) ((Deque A) -> A)))

--- a/queue/implicit.rkt
+++ b/queue/implicit.rkt
@@ -44,10 +44,11 @@
                                                  (Zero))]
     [(struct Deep (f m (struct Zero ()))) (Deep f m (One elem))]
     [(struct Deep (f m (struct One (el))))
-     (let ([forced-mid (force m)])
-       (Deep f (delay (cons (enqueue el (car forced-mid))
-                            (enqueue elem (cdr forced-mid))))
-             (Zero)))]))
+     (Deep f (delay 
+               (let ([forced-mid (force m)])
+                 (cons (enqueue el (car forced-mid))
+                       (enqueue elem (cdr forced-mid)))))
+           (Zero))]))
 
 ;; Returns the first element of the queue
 (: head : (All (A) ((Queue A) -> A)))

--- a/tests/implicitdeque-performance-tests.rkt
+++ b/tests/implicitdeque-performance-tests.rkt
@@ -1,0 +1,30 @@
+#lang racket
+(require "../deque/implicit.rkt")
+
+
+;; tests run with Racket 5.3.0.11, in DrRacket, 
+;; on a Intel i7-920 processor machine with 12GB memory
+
+
+;;;;; test enqueue
+
+; with bug
+; cpu time: 19828 real time: 19856 gc time: 9329
+
+; bug fixed (let* moved inside delay)
+; cpu time: 2797 real time: 2809 gc time: 532
+
+(time (build-deque 1000000 add1))
+
+
+;;;;; test enqueue-front
+
+; with bug
+; cpu time: 49500 real time: 49721 gc time: 15297
+
+; bug fixed (let* moved inside delay)
+; cpu time: 26953 real time: 26983 gc time: 2489
+
+(time
+ (for/fold ([dq (deque)]) ([i (in-range 1000000)])
+   (enqueue-front i dq)))

--- a/tests/implicitqueue-performance-tests.rkt
+++ b/tests/implicitqueue-performance-tests.rkt
@@ -1,0 +1,17 @@
+#lang racket
+(require "../queue/implicit.rkt")
+
+
+;; tests run with Racket 5.3.0.11, in DrRacket, 
+;; on a Intel i7-920 processor machine with 12GB memory
+
+
+;;;;; test enqueue
+
+; with bug
+; cpu time: 22234 real time: 22320 gc time: 11126
+
+; bug fixed (let* moved inside delay)
+; cpu time: 4703 real time: 4704 gc time: 1442
+
+(time (build-queue 1000000 add1))


### PR DESCRIPTION
- fixed lazy performance bug in implicit queue and implicit deque enqueue operations
- code now matches implementation from Okasaki book
- added performance benchmarks to expose the bug
