### PR TITLE
trie: use Immutable-HashTable type

### DIFF
--- a/pfds/trie.rkt
+++ b/pfds/trie.rkt
@@ -11,12 +11,12 @@
 (define-type-alias (Option A) (U Mt (Some A)))
 
 (define-struct: (K V) Trie ([opt : (Option V)]
-                            [map : (HashTable K (Trie K V))]))
+                            [map : (Immutable-HashTable K (Trie K V))]))
 
 (: empty : (All (K V) (-> (Trie K V))))
 (define (empty) 
   (make-Trie (make-Mt) 
-             (ann (make-immutable-hash null) (HashTable K (Trie K V)))))
+             (ann (make-immutable-hash null) (Immutable-HashTable K (Trie K V)))))
 
 (: lookup : (All (K V) ((Key K) (Trie K V) -> V)))
 (define (lookup keys map)
@@ -50,7 +50,7 @@
   (if (null? lstk)
       (make-Trie (make-Some val) 
                  (ann (make-immutable-hash null) 
-                      (HashTable K (Trie K V))))
+                      (Immutable-HashTable K (Trie K V))))
       (make-Trie (make-Mt) 
                  (make-immutable-hash 
                   (list (cons (car lstk) (build val (cdr lstk))))))))


### PR DESCRIPTION
Alternative to #6 
(Should probably wait until the next release to merge this.)

With this PR, John Clements code runs for me in 2ms.

```
#lang racket

(require pfds/trie)
(require (prefix-in f: pfds/trie-untyped))

(define (rand-list)
    (for/list ([i (in-range 128)])
          (random 256)))

(define t (trie (list (rand-list))))
(define u (time (bind (rand-list) 0 t)))

(define t* (f:trie (list (rand-list))))
(define u* (time (f:bind (rand-list) 0 t)))
```