### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/pfds/scribblings/functional-data-structures.scrbl
+++ b/pfds/scribblings/functional-data-structures.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@title[#:tag "top"]{@bold{Functional Data Structures} in Typed Racket}
+@title[#:tag "top"]{Functional Data Structures in Typed Racket}
 The data structures in this library are based on the work of
 Chris Okasaki and Phil Bagwell, including those in the
 @italic{Purely Functional Data Structures} by Okasaki.


### PR DESCRIPTION
For visual consistency with other packages within the docs