### PR TITLE
change polymorphic types to type constructors

### DIFF
--- a/pfds/delay.rkt
+++ b/pfds/delay.rkt
@@ -8,9 +8,8 @@
 ;; - Inner box is so TR can distinguished a forced promise from an unforced one
 ;;     I would have used a struct like Prom instead of the inner box, but TR
 ;;     cannnot distinguish structs from procedures?
-(define-type Promiseof
-  (All (A) (Boxof (U (-> (Boxof A))
-                     (Boxof A)))))
+(define-type (Promiseof A)
+  (Boxof (U (-> (Boxof A)) (Boxof A))))
 
 
 (define-syntax-rule (delay e) (box (λ () (box e))))

--- a/pfds/partialstream.rkt
+++ b/pfds/partialstream.rkt
@@ -1,12 +1,12 @@
 #lang typed/racket
 
-;; A "partial stream" is a list where the tail of each of the segments may or 
+;; A "partial stream" is a list where the tail of each of the segments may or
 ;; may not be delayed. Thus, both a completely eager list and a standard stream
 ;; (where all tails are delayed) are instances of a partial stream.
 
 ;; A partial stream is practically advantageous over a standard stream in cases
 ;; where delaying the tail has no benefit. An example is when the tail is null.
-;; Since null is already a value, delaying it has no advantages. Another example 
+;; Since null is already a value, delaying it has no advantages. Another example
 ;; is when the tail is the result of reversing a stream. Since reverse is a
 ;; monolithic operation, ie it traverses the entire list or stream regardless
 ;; of laziness, any suspensions in the result have no benefit (but still incur
@@ -17,9 +17,10 @@
 
 (provide PartialStreamof pscar pscdr psappend pstake psdrop psreverse)
 
-(define-type PartialStreamof (All (A) (Rec X (U Null
-                                                (Pair A X)
-                                                (Promiseof X)))))
+(define-type (PartialStreamof A)
+  (Rec X (U Null
+            (Pair A X)
+            (Promiseof X))))
 
 (: pscar : (All (A) ((PartialStreamof A) -> A)))
 (define (pscar lst)
@@ -33,12 +34,12 @@
         [(pair? lst) (cdr lst)]
         [else (pscdr (force lst))]))
 
-(: psappend : 
+(: psappend :
    (All (A) (PartialStreamof A) (PartialStreamof A) -> (PartialStreamof A)))
 (define (psappend l1 l2)
   (cond [(null? l1) l2]
         [(null? l2) l1]
-        [(pair? l1) (cons (car l1) (ann (delay (psappend (cdr l1) l2)) 
+        [(pair? l1) (cons (car l1) (ann (delay (psappend (cdr l1) l2))
                                         (PartialStreamof A)))]
         [else (psappend (force l1) l2)]))
 

--- a/pfds/stream.rkt
+++ b/pfds/stream.rkt
@@ -5,9 +5,8 @@
          stream->list drop take Stream
          #;stream-map #;stream-foldl #;stream-foldr)
 
-(define-type Stream
-  (All (A) (Rec Stream (U Null (Boxof (U (-> (Pair A Stream))
-                                         (Pair A Stream)))))))
+(define-type (Stream A) (Rec Stream (U Null (Boxof (U (-> (Pair A Stream))
+                                    (Pair A Stream))))))
 
 (define empty-stream null)
 
@@ -54,7 +53,7 @@
   (define (loop stream accum)
     (if (null? stream)
         accum
-        (loop (stream-cdr stream) 
+        (loop (stream-cdr stream)
               (ann (stream-cons (stream-car stream) accum) (Stream A)))))
   (loop stream empty-stream))
 
@@ -76,8 +75,8 @@
 
 (: drop : (All (A) (Integer (Stream A) -> (Stream A))))
 (define (drop num stream)
-  (cond 
-    [(zero? num)    stream] 
+  (cond
+    [(zero? num)    stream]
     [(null? stream) (error 'drop "not enough elements to drop")]
     [else (let ([forced (unbox stream)])
             (if (procedure? forced)
@@ -89,7 +88,7 @@
 
 (: take : (All (A) (Integer (Stream A) -> (Stream A))))
 (define (take num stream)
-  (cond 
+  (cond
     [(zero? num)    empty-stream]
     [(null? stream) (error 'take "not enough elements to take")]
     [else (let ([forced (unbox stream)])
@@ -102,44 +101,44 @@
 
 
 
-;(: stream-map : (All (A C B ...) ((A B ... B -> C) (Stream A) 
-;                                                   (Stream B) ... B -> 
+;(: stream-map : (All (A C B ...) ((A B ... B -> C) (Stream A)
+;                                                   (Stream B) ... B ->
 ;                                                   (Stream C))))
 ;(define (stream-map func strm . strms)
 ;  (if (or (empty? strm) (ormap empty? strms))
 ;      empty
-;      (delay (make-InStream (apply func 
-;                                   (stream-car strm) 
-;                                   (map stream-car strms)) 
-;                            (apply stream-map 
-;                                   func 
-;                                   (stream-cdr strm) 
+;      (delay (make-InStream (apply func
+;                                   (stream-car strm)
+;                                   (map stream-car strms))
+;                            (apply stream-map
+;                                   func
+;                                   (stream-cdr strm)
 ;                                   (map stream-cdr strms))))))
 ;
-;(: stream-foldl : 
-;   (All (C A B ...) ((C A B ... B -> C) C (Stream A) 
+;(: stream-foldl :
+;   (All (C A B ...) ((C A B ... B -> C) C (Stream A)
 ;                                        (Stream B) ... B -> C)))
 ;(define (stream-foldl func base fst . rst)
 ;  (if (or (empty? fst) (ormap empty? rst))
 ;      base
-;      (apply stream-foldl 
-;             func 
+;      (apply stream-foldl
+;             func
 ;             (apply func base (stream-car fst) (map stream-car rst))
 ;             (stream-cdr fst)
 ;             (map stream-cdr rst))))
 ;
-;(: stream-foldr : 
-;   (All (C A B ...) ((C A B ... B -> C) C (Stream A) 
+;(: stream-foldr :
+;   (All (C A B ...) ((C A B ... B -> C) C (Stream A)
 ;                                        (Stream B) ... B -> C)))
 ;(define (stream-foldr func base fst . rst)
 ;  (if (or (empty? fst) (ormap empty? rst))
 ;      base
-;      (apply func (apply stream-foldr 
-;                         func 
+;      (apply func (apply stream-foldr
+;                         func
 ;                         base
 ;                         (stream-cdr fst)
-;                         (map stream-cdr rst)) 
-;             (stream-car fst) 
+;                         (map stream-cdr rst))
+;             (stream-car fst)
 ;             (map stream-car rst))))
 ;
 


### PR DESCRIPTION
this fix ensured the code to be forward compatible with
the upcoming TR's [kind system](https://github.com/racket/typed-racket/pull/1143)